### PR TITLE
Implement gym module with domain models, CRUD, and integration

### DIFF
--- a/src/main/java/com/x86/followup/FollowupApplication.java
+++ b/src/main/java/com/x86/followup/FollowupApplication.java
@@ -2,8 +2,10 @@ package com.x86.followup;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FollowupApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/x86/followup/module/gym/application/service/GymService.java
+++ b/src/main/java/com/x86/followup/module/gym/application/service/GymService.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.service;
+
+public interface GymService {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/service/GymService.java
+++ b/src/main/java/com/x86/followup/module/gym/application/service/GymService.java
@@ -1,4 +1,22 @@
 package com.x86.followup.module.gym.application.service;
 
+import com.x86.followup.module.gym.domain.model.Gym;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
 public interface GymService {
+
+    void save(Gym gym);
+
+    void update(Gym gym);
+
+    void delete(Integer id);
+
+    List<Gym> findAll();
+
+    @Transactional(readOnly = true)
+    Optional<Gym> findById(Integer id);
+
 }

--- a/src/main/java/com/x86/followup/module/gym/application/service/GymServiceImpl.java
+++ b/src/main/java/com/x86/followup/module/gym/application/service/GymServiceImpl.java
@@ -1,4 +1,52 @@
 package com.x86.followup.module.gym.application.service;
 
-public class GymServiceImpl {
+import com.x86.followup.module.gym.application.usecase.*;
+import com.x86.followup.module.gym.domain.model.Gym;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class GymServiceImpl implements GymService {
+
+    private final GymSaveUseCase gymSaveUseCase;
+    private final GymUpdateUseCase gymUpdateUseCase;
+    private final GymDeleteUseCase gymDeleteUseCase;
+    private final GymFindByIdUseCase gymFindByIdUseCase;
+    private final GymFindAllUseCase gymFindAllUseCase;
+
+    @Override
+    @Transactional
+    public void save(Gym gym) {
+        gymSaveUseCase.execute(gym);
+    }
+
+    @Override
+    @Transactional
+    public void update(Gym gym) {
+        gymUpdateUseCase.execute(gym);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Integer id){
+        gymDeleteUseCase.execute(id);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public Optional<Gym> findById(Integer id){
+        return gymFindByIdUseCase.execute(id);
+    }
+
+    @Override
+    @Transactional
+    public List<Gym> findAll(){
+        return gymFindAllUseCase.execute();
+    }
+
 }

--- a/src/main/java/com/x86/followup/module/gym/application/service/GymServiceImpl.java
+++ b/src/main/java/com/x86/followup/module/gym/application/service/GymServiceImpl.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.service;
+
+public class GymServiceImpl {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymDeleteUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymDeleteUseCase.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.usecase;
+
+public class GymDeleteUseCase {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymDeleteUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymDeleteUseCase.java
@@ -1,4 +1,15 @@
 package com.x86.followup.module.gym.application.usecase;
 
+import com.x86.followup.module.gym.domain.model.GymId;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class GymDeleteUseCase {
+
+    private final GymRepository repository;
+
+    public void execute(Integer id){
+        this.repository.delete(new GymId(id));
+    }
 }

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindAllUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindAllUseCase.java
@@ -1,4 +1,18 @@
 package com.x86.followup.module.gym.application.usecase;
 
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
 public class GymFindAllUseCase {
+
+    private final GymRepository repository;
+
+    public List<Gym> execute(){
+        return repository.findAll();
+    }
+
 }

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindAllUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindAllUseCase.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.usecase;
+
+public class GymFindAllUseCase {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindByIdUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindByIdUseCase.java
@@ -1,4 +1,23 @@
 package com.x86.followup.module.gym.application.usecase;
 
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.model.GymId;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
 public class GymFindByIdUseCase {
+
+    private final GymRepository repository;
+
+    public Optional<Gym> execute(Integer id){
+        if (id == null){
+            return Optional.empty();
+        }
+        return repository.findById(new GymId(id));
+    }
+
 }

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindByIdUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymFindByIdUseCase.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.usecase;
+
+public class GymFindByIdUseCase {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymSaveUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymSaveUseCase.java
@@ -1,4 +1,18 @@
 package com.x86.followup.module.gym.application.usecase;
 
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class GymSaveUseCase {
+
+    private final GymRepository repository;
+
+    public void execute(Gym gym){
+        this.repository.save(gym);
+    }
+
 }

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymSaveUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymSaveUseCase.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.usecase;
+
+public class GymSaveUseCase {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymUpdateUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymUpdateUseCase.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.application.usecase;
+
+public class GymUpdateUseCase {
+}

--- a/src/main/java/com/x86/followup/module/gym/application/usecase/GymUpdateUseCase.java
+++ b/src/main/java/com/x86/followup/module/gym/application/usecase/GymUpdateUseCase.java
@@ -1,4 +1,25 @@
 package com.x86.followup.module.gym.application.usecase;
 
+import com.x86.followup.module.gym.domain.exception.GymNotFoundException;
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import com.x86.followup.module.user.domain.exception.UserNotFoundError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
 public class GymUpdateUseCase {
+
+    private final GymRepository repository;
+
+    public void execute(Gym gym){
+        if (gym.getId() == null || repository.findById(gym.getId()).isEmpty()) {
+            throw new GymNotFoundException("No se puede actualizar: Gym con ID "
+                    + (gym.getId() != null ? gym.getId().getValue() : "null")
+                    + " no encontrado.");
+        }
+        this.repository.update(gym);
+    }
+
 }

--- a/src/main/java/com/x86/followup/module/gym/domain/exception/GymExistException.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/exception/GymExistException.java
@@ -1,0 +1,7 @@
+package com.x86.followup.module.gym.domain.exception;
+
+public class GymExistException extends RuntimeException {
+    public GymExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/exception/GymNotFoundException.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/exception/GymNotFoundException.java
@@ -1,0 +1,7 @@
+package com.x86.followup.module.gym.domain.exception;
+
+public class GymNotFoundException extends RuntimeException {
+    public GymNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/Gym.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/Gym.java
@@ -1,7 +1,10 @@
 package com.x86.followup.module.gym.domain.model;
 
+import lombok.Getter;
+
 import java.util.Objects;
 
+@Getter
 public class Gym {
     private GymId id;
     private final GymName name;

--- a/src/main/java/com/x86/followup/module/gym/domain/model/Gym.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/Gym.java
@@ -1,0 +1,29 @@
+package com.x86.followup.module.gym.domain.model;
+
+import java.util.Objects;
+
+public class Gym {
+    private GymId id;
+    private final GymName name;
+    private final GymEmail email;
+    private final GymPhone phone;
+    private final GymAddress address;
+    private final GymPasswordHash passwordHash;
+    private final GymCreatedAt createdAt;
+
+    public Gym(GymId id,
+               GymName name,
+               GymEmail email,
+               GymPhone phone,
+               GymAddress address,
+               GymPasswordHash passwordHash,
+               GymCreatedAt createdAt) {
+        this.id = id;
+        this.name = Objects.requireNonNull(name, "El nombre no puede ser nulo");
+        this.email = Objects.requireNonNull(email, "El email no puede ser nulo");
+        this.phone = Objects.requireNonNull(phone, "El telefono no puede ser nulo");
+        this.address = Objects.requireNonNull(address, "La dirección no puede ser nula");
+        this.passwordHash = Objects.requireNonNull(passwordHash, "La contraseña no puede ser nula");
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymAddress.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymAddress.java
@@ -1,0 +1,10 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GymAddress {
+    private final String value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymCreatedAt.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymCreatedAt.java
@@ -1,0 +1,12 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.sql.Timestamp;
+
+@RequiredArgsConstructor
+@Getter
+public class GymCreatedAt {
+    private final Timestamp value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymEmail.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymEmail.java
@@ -1,0 +1,10 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GymEmail {
+    private final String value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymId.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymId.java
@@ -1,0 +1,10 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GymId {
+    private final Integer value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymName.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymName.java
@@ -1,0 +1,10 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GymName {
+    private final String value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymPasswordHash.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymPasswordHash.java
@@ -1,0 +1,10 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GymPasswordHash {
+    private final String value;
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/model/GymPhone.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/model/GymPhone.java
@@ -1,0 +1,23 @@
+package com.x86.followup.module.gym.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+@Getter
+public class GymPhone {
+    private static final String COLOMBIA_PHONE_PATTERN = "^3[0-9]{9}$";
+    private static final Pattern PATTERN = Pattern.compile(COLOMBIA_PHONE_PATTERN);
+
+    private final String value;
+
+    public boolean isValidPhone() {
+        if (value == null) {
+            return false;
+        }
+        String cleanValue = value.replaceAll("[\\s-]", "");
+        return PATTERN.matcher(cleanValue).matches();
+    }
+}

--- a/src/main/java/com/x86/followup/module/gym/domain/repository/GymRepository.java
+++ b/src/main/java/com/x86/followup/module/gym/domain/repository/GymRepository.java
@@ -1,0 +1,17 @@
+package com.x86.followup.module.gym.domain.repository;
+
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.model.GymId;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GymRepository {
+    Gym save(Gym gym);
+    void update (Gym gym);
+    void delete(GymId id);
+
+    List<Gym> findAll();
+    Optional<Gym> findById(GymId id);
+
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/adapter/PostgresGymAdapter.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/adapter/PostgresGymAdapter.java
@@ -1,4 +1,69 @@
 package com.x86.followup.module.gym.infrastructure.adapter;
 
-public class PostgresGymAdapter {
+import com.x86.followup.module.gym.domain.exception.GymNotFoundException;
+import com.x86.followup.module.gym.domain.model.Gym;
+import com.x86.followup.module.gym.domain.model.GymId;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import com.x86.followup.module.gym.infrastructure.mapper.GymMapper;
+import com.x86.followup.module.gym.infrastructure.persistence.GymEntity;
+import com.x86.followup.module.gym.infrastructure.persistence.JpaGymRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class PostgresGymAdapter implements GymRepository {
+
+    private final JpaGymRepository jpaGymRepository;
+    private final GymMapper gymMapper;
+
+    @Override
+    public Gym save(Gym gym){
+        GymEntity entity = gymMapper.toEntity(gym);
+
+        GymEntity savedEntity = jpaGymRepository.save(entity);
+
+        return gymMapper.toDomain(savedEntity);
+
+    }
+
+    @Override
+    @Transactional
+    public void update(Gym gym){
+
+        GymEntity existingEntity = jpaGymRepository.findById(gym.getId().getValue())
+                .orElseThrow(() -> new GymNotFoundException("Gym no encontrado para actualizar"));
+
+        existingEntity.setName(gym.getName().getValue());
+        existingEntity.setEmail(gym.getEmail().getValue());
+        existingEntity.setPhone(gym.getPhone().getValue());
+        existingEntity.setAddress(gym.getAddress().getValue());
+        existingEntity.setPassword(gym.getPasswordHash().getValue());
+
+        jpaGymRepository.save(existingEntity);
+    }
+
+    @Override
+    public void delete(GymId id){
+        jpaGymRepository.deleteById(id.getValue());
+    }
+
+    @Override
+    public Optional<Gym> findById(GymId id){
+        return jpaGymRepository.findById(id.getValue())
+                .map(gymMapper::toDomain);
+    }
+
+    @Override
+    public List<Gym> findAll(){
+        return jpaGymRepository.findAll()
+                .stream()
+                .map(gymMapper::toDomain)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/adapter/PostgresGymAdapter.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/adapter/PostgresGymAdapter.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.adapter;
+
+public class PostgresGymAdapter {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/GymController.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/GymController.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.controller;
+
+public class GymController {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/GymController.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/GymController.java
@@ -1,4 +1,97 @@
 package com.x86.followup.module.gym.infrastructure.controller;
 
+import com.x86.followup.module.gym.application.service.GymService;
+import com.x86.followup.module.gym.domain.exception.GymNotFoundException;
+import com.x86.followup.module.gym.domain.model.*;
+import com.x86.followup.module.gym.infrastructure.controller.dto.GymRequest;
+import com.x86.followup.module.gym.infrastructure.controller.dto.GymResponse;
+import com.x86.followup.module.gym.infrastructure.controller.dto.GymUpdateRequest;
+import com.x86.followup.module.user.infrastructure.controller.dto.UserUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/gym")
+@RequiredArgsConstructor
 public class GymController {
+
+    private final GymService gymService;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@RequestBody GymRequest request){
+        LocalDateTime now = LocalDateTime.now();
+
+        Gym newGym = new Gym(
+                null,
+                new GymName(request.name()),
+                new GymEmail(request.email()),
+                new GymPhone(request.phone()),
+                new GymAddress(request.address()),
+                new GymPasswordHash(request.password()),
+                new GymCreatedAt(Timestamp.valueOf(now))
+        );
+
+        gymService.save(newGym);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable Integer id, @RequestBody GymUpdateRequest request) {
+        Gym existingGym = gymService.findById(id)
+                .orElseThrow(() -> new GymNotFoundException("No se encontro el Gym para actualizar"));
+
+        Gym updateGym = new Gym(
+                existingGym.getId(),
+                request.name() != null ? new GymName(request.name()) : existingGym.getName(),
+                request.email() != null ? new GymEmail(request.email()) : existingGym.getEmail(),
+                request.phone() != null ? new GymPhone(request.phone()) : existingGym.getPhone(),
+                request.address() != null ? new GymAddress(request.address()) : existingGym.getAddress(),
+                request.password() != null ? new GymPasswordHash(request.password()) : existingGym.getPasswordHash(),
+                existingGym.getCreatedAt()
+        );
+        gymService.update(updateGym);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id){
+        gymService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<GymResponse> findById(@PathVariable Integer id){
+        GymId gymId = new GymId(id);
+        Gym gym = gymService.findById(gymId.getValue())
+                .orElseThrow(() -> new GymNotFoundException("El gym con el ID" + id + "no fue encontrado"));
+
+        return ResponseEntity.ok(mapToResponse(gym));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<GymResponse>> findAll(){
+        List<GymResponse> responses = gymService.findAll()
+                .stream()
+                .map(this::mapToResponse)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+
+    private GymResponse mapToResponse(Gym gym){
+        return new GymResponse(
+                gym.getId().getValue(),
+                gym.getName().getValue(),
+                gym.getEmail().getValue(),
+                gym.getPhone().getValue(),
+                gym.getAddress().getValue()
+        );
+    }
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymRequest.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymRequest.java
@@ -1,4 +1,9 @@
 package com.x86.followup.module.gym.infrastructure.controller.dto;
 
-public class GymRequest {
-}
+public record GymRequest(
+        String name,
+        String email,
+        String phone,
+        String address,
+        String password
+) {}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymRequest.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymRequest.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.controller.dto;
+
+public class GymRequest {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymResponse.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymResponse.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.controller.dto;
+
+public class GymResponse {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymResponse.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymResponse.java
@@ -1,4 +1,10 @@
 package com.x86.followup.module.gym.infrastructure.controller.dto;
 
-public class GymResponse {
+public record GymResponse(
+        Integer id,
+        String name,
+        String email,
+        String phone,
+        String address
+) {
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymUpdateRequest.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.controller.dto;
+
+public class GymUpdateRequest {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymUpdateRequest.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/controller/dto/GymUpdateRequest.java
@@ -1,4 +1,10 @@
 package com.x86.followup.module.gym.infrastructure.controller.dto;
 
-public class GymUpdateRequest {
+public record GymUpdateRequest(
+        String name,
+        String email,
+        String phone,
+        String address,
+        String password
+) {
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/mapper/GymMapper.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/mapper/GymMapper.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.mapper;
+
+public class GymMapper {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/mapper/GymMapper.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/mapper/GymMapper.java
@@ -1,4 +1,43 @@
 package com.x86.followup.module.gym.infrastructure.mapper;
 
+import com.x86.followup.module.gym.domain.model.*;
+import com.x86.followup.module.gym.infrastructure.persistence.GymEntity;
+import org.springframework.stereotype.Component;
+
+@Component
 public class GymMapper {
+
+    public GymEntity toEntity(Gym gym){
+        if (gym == null) return null;
+
+        GymEntity entity = new GymEntity();
+
+        if (gym.getId() != null) {
+            entity.setId(gym.getId().getValue());
+        }
+
+        entity.setName(gym.getName().getValue());
+        entity.setEmail(gym.getEmail().getValue());
+        entity.setPhone(gym.getPhone().getValue());
+        entity.setAddress(gym.getAddress().getValue());
+        entity.setPassword(gym.getPasswordHash().getValue());
+
+        return entity;
+    }
+
+    public Gym toDomain(GymEntity entity){
+        if (entity == null){
+            return null;
+        }
+
+        return new Gym(
+                new GymId(entity.getId()),
+                new GymName(entity.getName()),
+                new GymEmail(entity.getEmail()),
+                new GymPhone(entity.getPhone()),
+                new GymAddress(entity.getAddress()),
+                new GymPasswordHash(entity.getPassword()),
+                new GymCreatedAt(entity.getCreatedAt())
+                );
+    }
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/GymEntity.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/GymEntity.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.persistence;
+
+public class GymEntity {
+}

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/GymEntity.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/GymEntity.java
@@ -1,4 +1,35 @@
 package com.x86.followup.module.gym.infrastructure.persistence;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.sql.Timestamp;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "gimnasios")
+@Getter
+@Setter
 public class GymEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    private String email;
+
+    private String phone;
+
+    private String address;
+
+    private String password;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Timestamp createdAt;
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/JpaGymRepository.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/JpaGymRepository.java
@@ -1,4 +1,6 @@
 package com.x86.followup.module.gym.infrastructure.persistence;
 
-public interface JpaGymRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaGymRepository extends JpaRepository<GymEntity, Integer> {
 }

--- a/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/JpaGymRepository.java
+++ b/src/main/java/com/x86/followup/module/gym/infrastructure/persistence/JpaGymRepository.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.gym.infrastructure.persistence;
+
+public interface JpaGymRepository {
+}

--- a/src/main/java/com/x86/followup/module/shared/infrastructure/config/GymBeanConfig.java
+++ b/src/main/java/com/x86/followup/module/shared/infrastructure/config/GymBeanConfig.java
@@ -1,4 +1,25 @@
 package com.x86.followup.module.shared.infrastructure.config;
 
+import com.x86.followup.module.gym.application.usecase.*;
+import com.x86.followup.module.gym.domain.repository.GymRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class GymBeanConfig {
+
+    @Bean
+    public GymSaveUseCase gymSaveUseCase(GymRepository repository){ return new GymSaveUseCase(repository); }
+
+    @Bean
+    public GymUpdateUseCase gymUpdateUseCase(GymRepository repository){ return new GymUpdateUseCase(repository); }
+
+    @Bean
+    public GymDeleteUseCase gymDeleteUseCase(GymRepository repository){ return new GymDeleteUseCase(repository); }
+
+    @Bean
+    public GymFindByIdUseCase gymFindByIdUseCase(GymRepository repository){ return new GymFindByIdUseCase(repository); }
+
+    @Bean
+    public GymFindAllUseCase gymFindAllUseCase(GymRepository repository){ return new GymFindAllUseCase(repository); }
 }

--- a/src/main/java/com/x86/followup/module/shared/infrastructure/config/GymBeanConfig.java
+++ b/src/main/java/com/x86/followup/module/shared/infrastructure/config/GymBeanConfig.java
@@ -1,0 +1,4 @@
+package com.x86.followup.module.shared.infrastructure.config;
+
+public class GymBeanConfig {
+}

--- a/src/main/java/com/x86/followup/module/user/application/service/UserService.java
+++ b/src/main/java/com/x86/followup/module/user/application/service/UserService.java
@@ -1,8 +1,6 @@
 package com.x86.followup.module.user.application.service;
 
 import com.x86.followup.module.user.domain.model.User;
-import com.x86.followup.module.user.domain.model.UserId;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,9 +14,6 @@ public interface UserService {
 
     List<User> findAll();
 
-    Optional<User> findById(UserId id);
-
-    @Transactional(readOnly = true)
     Optional<User> findById(Integer id);
 
     Optional<User> findByIdentification(String identificationNumber);

--- a/src/main/java/com/x86/followup/module/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/x86/followup/module/user/application/service/UserServiceImpl.java
@@ -2,7 +2,6 @@ package com.x86.followup.module.user.application.service;
 
 import com.x86.followup.module.user.application.usecase.*;
 import com.x86.followup.module.user.domain.model.User;
-import com.x86.followup.module.user.domain.model.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,11 +42,6 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     public List<User> findAll() {
         return userFindAllUseCase.execute();
-    }
-
-    @Override
-    public Optional<User> findById(UserId id) {
-        return Optional.empty();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/x86/followup/module/user/domain/model/User.java
+++ b/src/main/java/com/x86/followup/module/user/domain/model/User.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class User {
     private UserId id;
+    private final UserGymId gymId;
     private final UserName name;
     private final UserIdentification identification;
     private final UserIdentificationType identificationType;
@@ -18,6 +19,7 @@ public class User {
     private final UserCreatedAt createdAt;
 
     public User(UserId id,
+                UserGymId gymId,
                 UserName name,
                 UserIdentification identification,
                 UserIdentificationType identificationType,
@@ -29,6 +31,7 @@ public class User {
                 UserCreatedAt createdAt) {
 
         this.id = id;
+        this.gymId = gymId;
         this.name = Objects.requireNonNull(name, "El nombre es obligatorio");
         this.identification = Objects.requireNonNull(identification, "La identificación es obligatoria");
         this.identificationType = Objects.requireNonNull(identificationType, "El tipo de identificación es obligatorio");

--- a/src/main/java/com/x86/followup/module/user/domain/model/UserGymId.java
+++ b/src/main/java/com/x86/followup/module/user/domain/model/UserGymId.java
@@ -1,0 +1,9 @@
+package com.x86.followup.module.user.domain.model;
+
+import java.util.Objects;
+
+public record UserGymId(Integer value) {
+    public UserGymId {
+        Objects.requireNonNull(value, "El gymId es obligatorio");
+    }
+}

--- a/src/main/java/com/x86/followup/module/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/x86/followup/module/user/domain/repository/UserRepository.java
@@ -18,5 +18,4 @@ public interface UserRepository {
     Optional<User> findById(UserId id);
     Optional<User> findByIdentification(UserIdentification identification);
 
-    void deleteById(UserId id);
 }

--- a/src/main/java/com/x86/followup/module/user/infrastructure/adapter/PostgresUserAdapter.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/adapter/PostgresUserAdapter.java
@@ -66,11 +66,6 @@ public class PostgresUserAdapter implements UserRepository {
     }
 
     @Override
-    public void deleteById(UserId id) {
-
-    }
-
-    @Override
     public Optional<User> findByIdentification(String identification) {
         return jpaRepository.findByIdentification_Identification(identification)
                 .map(userMapper::toDomain);

--- a/src/main/java/com/x86/followup/module/user/infrastructure/controller/UserController.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/controller/UserController.java
@@ -29,6 +29,7 @@ public class UserController {
 
         User newUser = new User(
                 null,
+                new UserGymId(request.gymId()),
                 new UserName(request.name()),
                 new UserIdentification(request.identification()),
                 UserIdentificationType.valueOf(request.identificationType()),
@@ -51,6 +52,7 @@ public class UserController {
 
         User updatedUser = new User(
                 existingUser.getId(),
+                request.gymId() != null ? new UserGymId(request.gymId()) : existingUser.getGymId(),
                 request.name() != null ? new UserName(request.name()) : existingUser.getName(),
                 request.identification() != null ? new UserIdentification(request.identification()) : existingUser.getIdentification(),
                 request.identificationType() != null ? UserIdentificationType.valueOf(request.identificationType()) : existingUser.getIdentificationType(),
@@ -92,6 +94,7 @@ public class UserController {
     private UserResponse mapToResponse(User user) {
         return new UserResponse(
                 user.getId().getValue(),
+                user.getGymId().value(),
                 user.getName().getValue(),
                 user.getPhone().getValue(),
                 user.getStatus().name(),

--- a/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserCreateRequest.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserCreateRequest.java
@@ -5,5 +5,6 @@ public record UserCreateRequest(
         String identification,
         String identificationType,
         String phone,
-        String paymentMethod
+        String paymentMethod,
+        Integer gymId
 ) {}

--- a/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserResponse.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserResponse.java
@@ -2,6 +2,7 @@ package com.x86.followup.module.user.infrastructure.controller.dto;
 
 public record UserResponse(
         Integer id,
+        Integer gymId,
         String name,
         String phone,
         String status,

--- a/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserUpdateRequest.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/controller/dto/UserUpdateRequest.java
@@ -14,5 +14,7 @@ public record UserUpdateRequest(
         String status,
 
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        LocalDateTime membershipEnd
+        LocalDateTime membershipEnd,
+
+        Integer gymId
 ) {}

--- a/src/main/java/com/x86/followup/module/user/infrastructure/mapper/UserMapper.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/mapper/UserMapper.java
@@ -17,6 +17,7 @@ public class UserMapper {
             entity.setId(user.getId().getValue());
         }
 
+        entity.setGymId(user.getGymId().value());
         entity.setName(user.getName().getValue());
         entity.setPhone(user.getPhone().getValue());
         entity.setPaymentMethod(UserPaymentMethod.valueOf(user.getPaymentMethod().name()));
@@ -39,6 +40,7 @@ public class UserMapper {
 
         return new User(
                 new UserId(entity.getId()),
+                new UserGymId(entity.getGymId()),
                 new UserName(entity.getName()),
                 new UserIdentification(entity.getIdentification().getIdentification()),
                 UserIdentificationType.valueOf(entity.getIdentification().getIdentificationType()),

--- a/src/main/java/com/x86/followup/module/user/infrastructure/persistence/JpaConfig.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/persistence/JpaConfig.java
@@ -1,8 +1,0 @@
-package com.x86.followup.module.user.infrastructure.persistence;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaConfig {}

--- a/src/main/java/com/x86/followup/module/user/infrastructure/persistence/UserEntity.java
+++ b/src/main/java/com/x86/followup/module/user/infrastructure/persistence/UserEntity.java
@@ -21,7 +21,7 @@ public class UserEntity {
     private Integer id;
 
     @Column(name = "gym_id")
-    private Integer gymId = 1;
+    private Integer gymId;
 
     private String name;
 


### PR DESCRIPTION
# 📝 feat(gym): implement initial gym module with hexagonal architecture and CRUD operations

---

## 📄 DESCRIPCIÓN GENERAL

Se implementa el módulo completo de **Gym** siguiendo una arquitectura hexagonal (ports & adapters), incluyendo dominio, casos de uso, servicios, controladores REST y persistencia con JPA.

Este cambio introduce la capacidad de gestionar gimnasios dentro del sistema mediante operaciones CRUD, además de establecer una base sólida y escalable para futuras funcionalidades relacionadas (multi-tenant, membresías, usuarios por gimnasio, etc.).

La motivación principal es desacoplar la lógica de negocio del framework y preparar el sistema para soportar múltiples gimnasios de forma consistente y mantenible.

---

## 🚀 CAMBIOS REALIZADOS

### 🧩 Dominio

* Se crea el agregado `Gym` con Value Objects:

  * `GymId`, `GymName`, `GymEmail`, `GymPhone`, `GymAddress`, `GymPasswordHash`, `GymCreatedAt`
* Implementación de validaciones básicas:

  * Null-safety en constructor (`Objects.requireNonNull`)
  * Validación de formato de teléfono colombiano (`GymPhone`)
* Definición de excepciones de dominio:

  * `GymNotFoundException`
  * `GymExistException`

### 🧠 Casos de Uso (Application Layer)

* Implementación de casos de uso desacoplados:

  * `GymSaveUseCase`
  * `GymUpdateUseCase`
  * `GymDeleteUseCase`
  * `GymFindByIdUseCase`
  * `GymFindAllUseCase`
* Separación clara de responsabilidades por operación (SRP)

### 🧱 Servicio de Aplicación

* Creación de `GymService` como fachada
* Implementación `GymServiceImpl` que orquesta casos de uso
* Uso de `@Transactional` en operaciones críticas

### 🌐 API REST

* Nuevo controlador: `GymController`
* Endpoints implementados:

  * `POST /api/v1/gym` → Crear gym
  * `PUT /api/v1/gym/{id}` → Actualizar gym
  * `DELETE /api/v1/gym/{id}` → Eliminar gym
  * `GET /api/v1/gym/{id}` → Obtener por ID
  * `GET /api/v1/gym` → Listar todos
* Uso de DTOs:

  * `GymRequest`, `GymUpdateRequest`, `GymResponse`

### 🗄️ Persistencia

* Implementación de adapter `PostgresGymAdapter` (Hexagonal)
* Integración con Spring Data:

  * `JpaGymRepository`
  * `GymEntity` con auditoría (`@CreatedDate`)
* Mapper explícito:

  * `GymMapper` (Domain ↔ Entity)

### ⚙️ Configuración

* Configuración manual de beans en `GymBeanConfig`
* Activación de auditoría JPA (`@EnableJpaAuditing`)

### 🔄 Cambios en módulo User

* Se introduce relación lógica con Gym:

  * Nuevo Value Object `UserGymId`
* Actualización de:

  * `User`, `UserEntity`, `UserMapper`, `UserController`, DTOs
* Eliminación de métodos redundantes:

  * `findById(UserId id)`
  * `deleteById(UserId id)` sin implementación

---

## 🧠 JUSTIFICACIÓN TÉCNICA

### 🏗️ Arquitectura

Se optó por **arquitectura hexagonal** para:

* Desacoplar dominio de infraestructura
* Facilitar testing (mock de puertos)
* Permitir cambios futuros de persistencia sin afectar lógica

### 🔍 Value Objects

Uso extensivo de Value Objects:

* Mejora la expresividad del dominio
* Reduce errores por tipos primitivos (primitive obsession)
* Facilita validaciones encapsuladas

### ⚖️ Trade-offs

* ❌ Mayor cantidad de clases (overhead inicial)
* ✅ Alta mantenibilidad y escalabilidad a largo plazo

### 🔄 Casos de Uso vs Service Layer

* Se evita lógica directa en controllers
* Los use cases encapsulan reglas específicas
* `GymService` actúa como orquestador (facade pattern)

### 🧵 Transaccionalidad

* Se define en service layer para mantener consistencia
* Separación entre operaciones read/write

---

## 🧪 CÓMO PROBAR LOS CAMBIOS

### 1. Setup

```bash
./mvnw spring-boot:run
```

### 2. Crear Gym

```http
POST /api/v1/gym
Content-Type: application/json

{
  "name": "Gym Test",
  "email": "test@gym.com",
  "phone": "3001234567",
  "address": "Calle 123",
  "password": "hashed_password"
}
```

### 3. Obtener Gym

```http
GET /api/v1/gym/{id}
```

### 4. Actualizar Gym

```http
PUT /api/v1/gym/{id}
Content-Type: application/json

{
  "name": "Updated Gym"
}
```

### 5. Listar Gyms

```http
GET /api/v1/gym
```

### 6. Eliminar Gym

```http
DELETE /api/v1/gym/{id}
```

### ✅ Resultado esperado

* CRUD completo funcional
* Persistencia en base de datos
* Respuestas HTTP correctas (201, 200, 204, 404)

---

## 📊 IMPACTO

### ⚡ Performance

* Bajo impacto
* Operaciones CRUD estándar sin queries complejas

### 🔐 Seguridad

* ⚠️ Password se guarda sin hashing explícito en este PR (riesgo identificado)
* Requiere mejora futura (bcrypt/argon2)

### 🎯 UX / API

* API consistente y RESTful
* DTOs claros y desacoplados del dominio

### 🧱 Backend / Infraestructura

* Introducción de nueva capa arquitectónica
* Mejora significativa en organización del código

---

## ⚠️ RIESGOS Y CONSIDERACIONES

* ❗ No se valida unicidad de email (posibles duplicados)
* ❗ Password no encriptado aún
* ❗ Validaciones de dominio limitadas (solo null y formato básico)
* ❗ `GymPhone.isValidPhone()` no se usa en flujo actual
* ❗ Posible inconsistencia si `GymId` es null en update

---

## 🔄 BREAKING CHANGES

**Sí**

### Cambios en módulo User:

* Se añade `gymId` como atributo obligatorio en:

  * `User`
  * DTOs (`UserCreateRequest`, `UserUpdateRequest`, `UserResponse`)
* Eliminación de métodos:

  * `findById(UserId id)`
  * `deleteById(UserId id)`

### 🔧 Migración

* Actualizar payloads de creación/actualización de usuario para incluir `gymId`
* Revisar integraciones que usen métodos eliminados

---

## 📦 DEPENDENCIAS

* No se agregan nuevas dependencias externas
* Uso de:

  * Spring Boot
  * Spring Data JPA
  * Lombok (ya existente)

---

## ✅ CHECKLIST DE CALIDAD

* [x] Código sigue estándares del proyecto
* [x] Principios SOLID aplicados
* [x] Arquitectura desacoplada (Hexagonal)
* [ ] Tests unitarios añadidos (pendiente)
* [ ] Tests de integración añadidos (pendiente)
* [x] No hay logs/debug innecesarios
* [x] DTOs correctamente definidos
* [x] Mappers explícitos
* [ ] Validaciones completas (pendiente)
* [ ] Seguridad (hash de password) pendiente
* [ ] Revisado por al menos 1 miembro del equipo

---

## 📎 NOTAS ADICIONALES

### 🔮 Mejoras futuras recomendadas

1. **Seguridad**

   * Implementar hashing de contraseñas (BCrypt)
   * Validación de email único

2. **Validaciones**

   * Integrar Bean Validation (`@Valid`)
   * Validaciones en Value Objects más robustas

3. **Testing**

   * Unit tests para use cases
   * Integration tests para controller

4. **Arquitectura**

   * Considerar uso de factories para creación de agregados
   * Event sourcing o domain events (a futuro)

5. **Multi-tenant readiness**

   * Este módulo sienta base para aislar datos por gym

---

> ⚠️ Se recomienda revisión enfocada en:
>
> * Consistencia de arquitectura hexagonal
> * Validaciones de dominio
> * Seguridad en manejo de credenciales
